### PR TITLE
#29 : Fixing issue where message body previews were showing the wrong…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.shamrice.discapp.notification</groupId>
     <artifactId>discapp-notification-service</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
 
     <properties>
         <java.version>15</java.version>

--- a/src/main/resources/banner.txt
+++ b/src/main/resources/banner.txt
@@ -9,6 +9,6 @@
 
      By: Erik Eriksen
      Web: https://github.com/shamrice/discapp-notifier
-     Version: 2.2.1
+     Version: 2.2.2
 
 *******************************************************************************


### PR DESCRIPTION
… half of the truncated body when they length exceeded the max preview size. I also made the max preview size configurable. (Default is 500 characters)